### PR TITLE
Don't persist library list filter

### DIFF
--- a/Movie DB/CoreData/Model/FilterSetting/FilterSetting+CoreDataClass.swift
+++ b/Movie DB/CoreData/Model/FilterSetting/FilterSetting+CoreDataClass.swift
@@ -15,19 +15,8 @@ import SwiftUI
 @objc(FilterSetting)
 public class FilterSetting: NSManagedObject {
     static let shared: FilterSetting = {
-        // Load the filter setting or create a new one
-        if let id = UserDefaults.standard.object(forKey: JFLiterals.Keys.filterSetting) as? String {
-            // Fetch the FilterSetting with the loaded UUID
-            let fetchRequest: NSFetchRequest<FilterSetting> = FilterSetting.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "%K = %@", Schema.FilterSetting.id.rawValue, id)
-            fetchRequest.fetchLimit = 1
-            if let result = try? PersistenceController.viewContext.fetch(fetchRequest).first {
-                return result
-            }
-        }
-        // Create a new FilterSetting and store its ID for further retrieval
+        // Create a new FilterSetting (will be saved in the viewContext and cleaned up later at app start)
         let newFilterSetting = FilterSetting(with: PersistenceController.viewContext)
-        UserDefaults.standard.set(newFilterSetting.id?.uuidString, forKey: JFLiterals.Keys.filterSetting)
         PersistenceController.saveContext()
         return newFilterSetting
     }()

--- a/Movie DB/Utility/JFLiterals.swift
+++ b/Movie DB/Utility/JFLiterals.swift
@@ -54,8 +54,6 @@ enum JFLiterals {
         static let posterDenyList = "posterDenyList"
         /// The time in seconds since 1970 (``Date.timeIntervalSince1970``) when the poster deny list has last been updated
         static let posterDenyListLastUpdated = "posterDenyListLastUpdated"
-        /// The id of the filter settings used for filtering in the library home
-        static let filterSetting = "filterSetting"
         /// The number of times the app has asked for app store ratings
         static let askedForAppRating = "askedForRating"
         /// The date when the app was first opened


### PR DESCRIPTION
This PR changes the way the library filter settings are handled.

Instead of persisting the filter across app restarts, we now create a new filter setting at app start.