### PR TITLE
Background updates

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ opt_in_rules:
   - array_init
   - balanced_xctest_lifecycle
   - collection_alignment
-  - conditional_returns_on_newline
   - contains_over_filter_count
   - contains_over_filter_is_empty
   - contains_over_first_not_nil
@@ -71,6 +70,14 @@ opt_in_rules:
 analyzer_rules:
   - unused_declaration
   - unused_import
+
+custom_rules:
+  single_line_guard:
+    included: ".*.swift"
+    regex: 'guard[^\{]{2,80}else\s*\{\s*\n\s*return.{2,40}\}'
+    name: "Single Line Guard"
+    message: "Use a single line guard for simple checks."
+    severity: warning
 
 force_cast: warning
 force_try: warning

--- a/Movie DB.xcodeproj/project.pbxproj
+++ b/Movie DB.xcodeproj/project.pbxproj
@@ -80,14 +80,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		AB5029FA2D58AE1B00D7DD9B /* Exceptions for "SupportingFiles" folder in "Movie DB" target */ = {
+		AB5029FA2D58AE1B00D7DD9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = AB6718BC22C0312A00F429E4 /* Movie DB */;
 		};
-		AB8965252D57C58100F54EB1 /* Exceptions for "Movie DBTests" folder in "Movie DBTests" target */ = {
+		AB8965252D57C58100F54EB1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -98,162 +98,20 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		AB5027AB2D58AD8700D7DD9B /* Utility */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Utility;
-			sourceTree = "<group>";
-		};
-		AB5027C02D58AD8700D7DD9B /* Preview Content */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		AB5027CD2D58AD8700D7DD9B /* CSV */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = CSV;
-			sourceTree = "<group>";
-		};
-		AB5028222D58AD8700D7DD9B /* CoreData */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = CoreData;
-			sourceTree = "<group>";
-		};
-		AB50287B2D58AD8700D7DD9B /* Models */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		AB5028962D58AD8700D7DD9B /* APIs */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = APIs;
-			sourceTree = "<group>";
-		};
-		AB5028A02D58AD8700D7DD9B /* Migrations */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Migrations;
-			sourceTree = "<group>";
-		};
-		AB50293A2D58AD8700D7DD9B /* Views */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
-		AB5029DA2D58AD8700D7DD9B /* Localization */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Localization;
-			sourceTree = "<group>";
-		};
-		AB5029F82D58AD8B00D7DD9B /* SupportingFiles */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				AB5029FA2D58AE1B00D7DD9B /* Exceptions for "SupportingFiles" folder in "Movie DB" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = SupportingFiles;
-			sourceTree = "<group>";
-		};
-		AB5029F92D58AD9A00D7DD9B /* Resources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		AB8965132D57C58100F54EB1 /* Movie DBTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				AB8965252D57C58100F54EB1 /* Exceptions for "Movie DBTests" folder in "Movie DBTests" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = "Movie DBTests";
-			sourceTree = "<group>";
-		};
-		AB89652F2D57C5C400F54EB1 /* Movie DBUITests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = "Movie DBUITests";
-			sourceTree = "<group>";
-		};
-		AB89653B2D57C5C900F54EB1 /* Movie DBScreenshots */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = "Movie DBScreenshots";
-			sourceTree = "<group>";
-		};
+		AB5027AB2D58AD8700D7DD9B /* Utility */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Utility; sourceTree = "<group>"; };
+		AB5027C02D58AD8700D7DD9B /* Preview Content */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Preview Content"; sourceTree = "<group>"; };
+		AB5027CD2D58AD8700D7DD9B /* CSV */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CSV; sourceTree = "<group>"; };
+		AB5028222D58AD8700D7DD9B /* CoreData */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CoreData; sourceTree = "<group>"; };
+		AB50287B2D58AD8700D7DD9B /* Models */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Models; sourceTree = "<group>"; };
+		AB5028962D58AD8700D7DD9B /* APIs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = APIs; sourceTree = "<group>"; };
+		AB5028A02D58AD8700D7DD9B /* Migrations */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Migrations; sourceTree = "<group>"; };
+		AB50293A2D58AD8700D7DD9B /* Views */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Views; sourceTree = "<group>"; };
+		AB5029DA2D58AD8700D7DD9B /* Localization */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Localization; sourceTree = "<group>"; };
+		AB5029F82D58AD8B00D7DD9B /* SupportingFiles */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (AB5029FA2D58AE1B00D7DD9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SupportingFiles; sourceTree = "<group>"; };
+		AB5029F92D58AD9A00D7DD9B /* Resources */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Resources; sourceTree = "<group>"; };
+		AB8965132D57C58100F54EB1 /* Movie DBTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (AB8965252D57C58100F54EB1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "Movie DBTests"; sourceTree = "<group>"; };
+		AB89652F2D57C5C400F54EB1 /* Movie DBUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Movie DBUITests"; sourceTree = "<group>"; };
+		AB89653B2D57C5C900F54EB1 /* Movie DBScreenshots */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Movie DBScreenshots"; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/Movie DB/AppDelegate.swift
+++ b/Movie DB/AppDelegate.swift
@@ -58,7 +58,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             }
         }
 
-        // MARK: Background Fetch
+        // MARK: Background Processing
         // No need to keep a persistent reference
         let backgroundHandler = BackgroundHandler()
         backgroundHandler.setupBackgroundFetch()

--- a/Movie DB/BackgroundHandler.swift
+++ b/Movie DB/BackgroundHandler.swift
@@ -37,7 +37,7 @@ class BackgroundHandler {
     /// Schedules a background fetch to be executed ``bgTaskInterval`` from now.
     /// If there is already a background fetch scheduled, re-scheduling will be skipped.
     private func scheduleBackgroundFetch() async {
-        let pendingTasks = await BGTaskScheduler.shared.getPendingTaskRequests()
+        let pendingTasks = await BGTaskScheduler.shared.pendingTaskRequests()
         // Only schedule, if there is not already one scheduled
         guard pendingTasks.isEmpty else { return }
 
@@ -62,7 +62,7 @@ class BackgroundHandler {
         let operation = Task(priority: .high) {
             do {
                 Logger.background.info("Updating Library from background task...")
-                try await MediaLibrary.shared.reloadAll()
+                try await MediaLibrary.shared.reloadAll(fromBackground: true)
                 Logger.background.info("Reloaded all media objects.")
                 bgTask.setTaskCompleted(success: true)
             } catch {
@@ -76,16 +76,6 @@ class BackgroundHandler {
         bgTask.expirationHandler = {
             Logger.background.info("Cancelling background task...")
             operation.cancel()
-        }
-    }
-}
-
-extension BGTaskScheduler {
-    func getPendingTaskRequests() async -> [BGTaskRequest] {
-        await withCheckedContinuation { continuation in
-            getPendingTaskRequests { requests in
-                continuation.resume(returning: requests)
-            }
         }
     }
 }

--- a/Movie DB/BackgroundHandler.swift
+++ b/Movie DB/BackgroundHandler.swift
@@ -13,7 +13,8 @@ import UIKit
 
 class BackgroundHandler {
     static let bgTaskID = "de.JonasFrey.Movie-DB.updateLibrary"
-    static let bgTaskInterval: TimeInterval = 3 * .day
+    // Run the background task every day
+    static let bgTaskInterval: TimeInterval = .day
     
     init() {}
     

--- a/Movie DB/CSV/CSVExporter.swift
+++ b/Movie DB/CSV/CSVExporter.swift
@@ -111,8 +111,8 @@ class CSVExporter {
             // Double all quotation marks in the value (escape them)
             stringValue = stringValue.replacingOccurrences(of: "\"", with: "\"\"")
             
-            // If the value contains a separator, encapsulate the value in quotation marks
-            if stringValue.contains(separator) {
+            // If the value contains a separator or starts with quotation marks, encapsulate the value in quotation marks
+            if stringValue.contains(separator) || stringValue.starts(with: "\"") {
                 stringValue = "\"\(stringValue)\""
             }
             

--- a/Movie DB/CoreData/Model/Media/Media+CoreDataClass.swift
+++ b/Movie DB/CoreData/Model/Media/Media+CoreDataClass.swift
@@ -148,6 +148,12 @@ public class Media: NSManagedObject {
         assertionFailure("Implement in subclasses!")
         return nil
     }
+
+    func waitForThumbnailDownload() async {
+        if let loadThumbnailTask {
+            _ = await loadThumbnailTask.value
+        }
+    }
 }
 
 // MARK: - Core Data

--- a/Movie DB/CoreData/Model/Media/Media+CoreDataClass.swift
+++ b/Movie DB/CoreData/Model/Media/Media+CoreDataClass.swift
@@ -81,6 +81,8 @@ public class Media: NSManagedObject {
                 self.parentalRating = managedObjectContext.importDummy(rating)
             }
             self.watchProviders = Set(managedObjectContext.importDummies(tmdbData.watchProviders))
+            // Also called for the initial load
+            self.lastUpdated = .now
         }
     }
     

--- a/Movie DB/CoreData/Model/Media/Media+CoreDataProperties.swift
+++ b/Movie DB/CoreData/Model/Media/Media+CoreDataProperties.swift
@@ -115,7 +115,9 @@ public extension Media {
     @NSManaged var userLists: Set<UserMediaList>
     /// The date the user watched the media
     @NSManaged var watchDate: Date?
-    
+    /// The date when the media object was last updated (i.e., synchronized with the remote API)
+    @NSManaged var lastUpdated: Date?
+
     // MARK: - Computed Properties
     
     /// The year of the release or first airing of the media

--- a/Movie DB/CoreData/Model/Media/Schema+Media.swift
+++ b/Movie DB/CoreData/Model/Media/Schema+Media.swift
@@ -62,7 +62,8 @@ extension Schema {
         case isFavorite
         case isOnWatchlist
         case watchDate
-        
+        case lastUpdated
+
         // MARK: Relationships
         case genres
         case tags

--- a/Movie DB/CoreData/Persistence.swift
+++ b/Movie DB/CoreData/Persistence.swift
@@ -49,6 +49,7 @@ class PersistenceController {
         // swiftlint:disable:previous function_body_length
         if !Thread.isMainThread {
             Logger.lifeCycle.error("Creating PersistenceController on a background thread. This may cause a deadlock.")
+            assertionFailure()
         }
         // If we already have an existing model, reuse it
         if let model = Self.model {

--- a/Movie DB/Models/MediaLibrary.swift
+++ b/Movie DB/Models/MediaLibrary.swift
@@ -193,7 +193,7 @@ struct MediaLibrary {
         if fromBackground {
             // Don't update medias that were updated in the last x days
             // => only update medias that were last updated before the cutoff date
-            let cutoffDate = Date.now.addingTimeInterval(-BackgroundHandler.bgTaskInterval)
+            let cutoffDate = Date.now.addingTimeInterval(-7 * .day)
             fetchRequest.predicate = NSPredicate(
                 format: "%K == nil OR %K < %@",
                 Schema.Media.lastUpdated.rawValue,

--- a/Movie DB/Models/MediaLibrary.swift
+++ b/Movie DB/Models/MediaLibrary.swift
@@ -182,15 +182,33 @@ struct MediaLibrary {
     
     /// Reloads all media objects in the library by re-fetching their TMDBData
     /// - Parameter completion: A closure that will be executed when the reload has finished, providing the last occurred error
-    func reloadAll() async throws {
+    func reloadAll(fromBackground: Bool = false) async throws {
         // Create a new child context to perform the reload in
         let reloadContext = context.newBackgroundContext()
         
         // Fetch all media objects from the store (using the reload context)
         let fetchRequest: NSFetchRequest<Media> = Media.fetchRequest()
+        // Nil values are sorted at the top, followed by the medias that were longest not updated
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Media.lastUpdated, ascending: true)]
+        if fromBackground {
+            // Don't update medias that were updated in the last x days
+            // => only update medias that were last updated before the cutoff date
+            let cutoffDate = Date.now.addingTimeInterval(-BackgroundHandler.bgTaskInterval)
+            fetchRequest.predicate = NSPredicate(
+                format: "%K == nil OR %K < %@",
+                Schema.Media.lastUpdated.rawValue,
+                Schema.Media.lastUpdated.rawValue,
+                cutoffDate as NSDate
+            )
+        }
         let medias = (try? reloadContext.fetch(fetchRequest)) ?? []
         Logger.library.info("Reloading \(medias.count) media objects.")
-        
+
+        guard !medias.isEmpty else {
+            lastUpdated = Date.now.timeIntervalSince1970
+            return
+        }
+
         // Reload all media objects using a task group
         try await withThrowingTaskGroup(of: Void.self) { group in
             for media in medias {
@@ -212,13 +230,21 @@ struct MediaLibrary {
                     }
                     try Task.checkCancellation()
                     mainMedia?.loadThumbnail(force: true)
+                    // If we are in a background task, wait for the thumbnail download to finish
+                    if fromBackground {
+                        await mainMedia?.waitForThumbnailDownload()
+                    }
                 }
             }
-            // We don't need to wait for all the thumbnails to finish loading, we can just exit here
+            if fromBackground {
+                // Wait for all thumbnails to finish downloading
+                try await group.waitForAll()
+            }
         }
         // Since we just reloaded all media, they are all up-to-date
         // We also need this, in the case of an invalid set lastUpdated value that prevents the update to work
         lastUpdated = Date.now.timeIntervalSince1970
+        PersistenceController.saveContext()
     }
     
     /// Resets the library, deleting everything!

--- a/Movie DB/SupportingFiles/Info.plist
+++ b/Movie DB/SupportingFiles/Info.plist
@@ -49,7 +49,6 @@
 	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>fetch</string>
 		<string>processing</string>
 		<string>remote-notification</string>
 	</array>

--- a/Movie DB/SupportingFiles/Movie DB.xcdatamodeld/.xccurrentversion
+++ b/Movie DB/SupportingFiles/Movie DB.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Movie DB v16.xcdatamodel</string>
+	<string>Movie DB v17.xcdatamodel</string>
 </dict>
 </plist>

--- a/Movie DB/SupportingFiles/Movie DB.xcdatamodeld/Movie DB v17.xcdatamodel/contents
+++ b/Movie DB/SupportingFiles/Movie DB.xcdatamodeld/Movie DB v17.xcdatamodel/contents
@@ -53,6 +53,7 @@
         <attribute name="isFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isOnWatchlist" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="keywords" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer" customClassName="[String]"/>
+        <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="modificationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="notes" attributeType="String" defaultValueString=""/>
         <attribute name="originalLanguage" optional="YES" attributeType="String"/>


### PR DESCRIPTION
This PR once again tries to fix the broken background updates by using a processing task, instead of an app refresh task. 

This way we should have more time to do processing-intensive work.

The background task tries to run every day, but only updates media that is older than 7 days.